### PR TITLE
enable monitoring APIs

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -27,7 +27,11 @@ in {
       hostName = cfg.hostName;
     };
 
-    services.jitsi-videobridge.openFirewall = true;
+    services.jitsi-videobridge = {
+      openFirewall = true;
+      apis = [ "colibri" "rest" ];
+    };
+
     networking.firewall.allowedTCPPorts = [ 80 443 ];
   };
 }


### PR DESCRIPTION
Turn on monitoring APIs, which can be scraped by the prometheus jitsi exporter.